### PR TITLE
feat: event 쿼리 함수 stale 타임 변경

### DIFF
--- a/src/components/main/CardContainer.tsx
+++ b/src/components/main/CardContainer.tsx
@@ -17,7 +17,6 @@ const CardContainer = ({ data }: CardContainerPropsType) => {
   const setFavoriteIds = useSetRecoilState(mainCartId)
 
   const productLists = useGetProductsList(allProductCurrentPage)
-  console.log(productLists)
 
   const useGetFavorite = async () => {
     const res = await getFavorite()

--- a/src/components/main/MainEvent.tsx
+++ b/src/components/main/MainEvent.tsx
@@ -1,33 +1,14 @@
 import React from 'react'
 import { useNavigate } from 'react-router'
 import ViewMoreBtn from './common/ViewMoreBtn'
+import { InEventMainList, useGetEvent } from './hooks/useEventLists'
 
 // 지울 것
-const events = [
-  {
-    id: '1',
-    img: 'https://user-images.githubusercontent.com/90392240/193076598-f4c40be6-215a-4c11-9cd4-30d15c7d830d.png',
-    description: '이벤트 내용'
-  },
-  {
-    id: '2',
-    img: 'https://user-images.githubusercontent.com/90392240/193076604-8d324e4b-0519-4cc8-a8fa-9f538f398103.png',
-    description: '이벤트 내용'
-  },
-  {
-    id: '3',
-    img: 'https://user-images.githubusercontent.com/90392240/193076590-2067de1e-7f25-4a52-a8e3-89c8051b14b6.png',
-    description: '이벤트 내용'
-  },
-  {
-    id: '4',
-    img: 'https://user-images.githubusercontent.com/90392240/193076592-d71a3a5c-ab7d-4908-b2a8-2c3e497d5e07.png',
-    description: '이벤트 내용'
-  }
-]
 
 const MainEvent = () => {
   const navigate = useNavigate()
+
+  const eventList = useGetEvent()
 
   return (
     <div>
@@ -37,20 +18,20 @@ const MainEvent = () => {
         </span>
       </div>
       <div className="grid sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-2 mx-2  md:gap-8 md:px-12">
-        {events.map((event: any) => (
+        {eventList?.data?.eventMainList?.map((event: InEventMainList) => (
           <div
-            key={event.id}
+            key={event.eventId}
             className="w-full xs-max:h-[215px] rounded-xl flex flex-col items-center my-2 shadow-basic hover:cursor-pointer"
             onClick={() => navigate('/event')}
           >
             <img
               className="w-full h-[145px] md:h-[226px] rounded-t-xl object-fit md:object-cover"
-              src={event.img}
+              src={event.imageUrl}
               alt=""
             />
             <div className=" h-[95px] rounded-b-xl">
               {/* 이벤트 내용 */}
-              {event.description}
+              {event.eventTitle}
             </div>
           </div>
         ))}

--- a/src/components/main/common/Pagination.tsx
+++ b/src/components/main/common/Pagination.tsx
@@ -9,8 +9,8 @@ interface PropsType {
 
 function Pagination({ currentPage, allCount, setCurrentPage }: PropsType) {
   const [pagesCount, setPagesCount] = useState<number[] | []>([])
-  const maxPage = Math.floor(allCount / 10)
-
+  const maxPage = Math.ceil(allCount / 10)
+  console.log(allCount)
   useEffect(() => {
     const arr = []
     for (let i = 1; i <= maxPage; i++) {

--- a/src/components/main/hooks/useEventLists.ts
+++ b/src/components/main/hooks/useEventLists.ts
@@ -10,30 +10,35 @@ export interface EventDetailResponseType {
   endTime: Date
   imageUrl: String[]
 }
-
-export interface EventMainList {
+export interface InEventMainList {
   eventId: number
   eventTitle: string
   imageUrl: string
 }
 
 export interface EventResponseType {
-  eventMainList: EventMainList[]
-  totalCount: number
+  data: {
+    eventMainList: InEventMainList[]
+    totalCount: number
+  }
+  status: number
+  message: string
 }
 
-const getEvents = async (): Promise<EventResponseType> => {
+export const getEvents = async (): Promise<EventResponseType> => {
   const { data }: AxiosResponse<EventResponseType> = await axiosInstance({
     url: '/event/main',
     headers: {
       ContentType: 'application/json'
     }
   })
+
   return data
 }
 export const useGetEvent = () => {
   const { data } = useQuery([queryKeys.allEvent], () => getEvents(), {
-    refetchOnWindowFocus: false
+    refetchOnWindowFocus: false,
+    staleTime: 900000
   })
   return data
 }

--- a/src/components/main/hooks/useProductLists.ts
+++ b/src/components/main/hooks/useProductLists.ts
@@ -9,7 +9,6 @@ const getProductsList = async (pageNo: number): Promise<ProductResponseType[]> =
     data: { data }
   } = await axiosInstance({
     url: `/product/main?page=${pageNo}&memberId=0&size=9`,
-    // url: '/main/product?page=1&memberId=0&size=9',
     headers: {
       ContentType: 'application/json'
     }
@@ -23,13 +22,12 @@ export const useGetProductsList = (pageNo: number): ProductResponseType[] => {
     keepPreviousData: true,
     refetchOnWindowFocus: false
   })
-  console.log(data)
   return data
 }
 
 export const usePrefetchProductLists = (currentPage: number, count: number): void => {
   const queryClient = useQueryClient()
-  const maxPage = Math.floor(count / 10)
+  const maxPage = Math.ceil(count / 10)
   if (maxPage > currentPage) {
     const nextPage = currentPage + 1
     queryClient.prefetchQuery([queryKeys.product, nextPage], () => getProductsList(nextPage))

--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -1,12 +1,7 @@
 import { useNavigate } from 'react-router'
 import PageLayout from '../components/common/ui/PageLayout'
 import CardTemplate from './../components/common/ui/CardTemplate'
-import {
-  EventMainList,
-  EventResponseType,
-  useGetDetailEvent,
-  useGetEvent
-} from '../components/main/hooks/useEventLists'
+import { InEventMainList, useGetDetailEvent, useGetEvent } from '../components/main/hooks/useEventLists'
 import { useEffect, useState } from 'react'
 import Pagination from './../components/main/common/Pagination'
 import Search from '../components/main/common/Search'
@@ -48,7 +43,7 @@ function EventPage() {
           <div className=" grid sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-2 justify-items-stretch  md:gap-8 md:px-12">
             {/* eventList.map */}
             {eventList &&
-              eventList?.eventMainList?.map((event: EventMainList) => (
+              eventList?.data?.eventMainList.map((event: InEventMainList) => (
                 <div
                   key={event.eventId}
                   className="w-full rounded-xl xs-max:h-[215px] flex flex-col items-center my-2 shadow-basic hover:cursor-pointer"
@@ -67,7 +62,13 @@ function EventPage() {
               ))}
           </div>
           <div className="relative flex justify-center items-center">
-            <Pagination currentPage={currentPage} setCurrentPage={setCurrentPage} allCount={50} />
+            {eventList?.data?.totalCount && (
+              <Pagination
+                currentPage={currentPage}
+                setCurrentPage={setCurrentPage}
+                allCount={eventList.data.totalCount}
+              />
+            )}
             <Search />
           </div>
         </CardTemplate>


### PR DESCRIPTION
## 개요

이벤트와 공지사항은 메인페이지에서 무조건 한 번은 불러오는데 이벤트 페이지와 공지사항 페이지에서 또 데이터 페칭을 해야되는지 고민이 들었다. (서버 호출 줄이는게 좋지 않나)

## 작업사항

서버 데이터를 페칭해 와서 사용하는 것이기 때문에 recoil의 사용보다는 react-query 내에서 해결하려고 2번을 사용했다

## 변경로직

react-query 함수 옵션에 staleTime 15분으로 변경
